### PR TITLE
add godoc examples, clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,61 +16,12 @@ Install this library using `go get`:
     $ go get github.com/mittwald/go-helm-client
 
 ## Usage
-Construct a new Helm client, then use the various services on the client to manage helm chart repositories and releases:
-```go 
-package main
+Example usage of the client can be found in the [package examples](https://pkg.go.dev/github.com/mittwald/go-helm-client?tab=doc#pkg-examples).
 
-import (
-	"github.com/mittwald/go-helm-client"
-	"helm.sh/helm/v3/pkg/repo"
-)
+#### Private chart repository
+When working with private repositories, you can utilize the `Username` and `Password` parameters of a chart entry to specify credentials.
 
-func main() {
-	// Create a client
-	helmClient, err := helmclient.New(&helmclient.Options{
-		RepositoryCache:  "/tmp/.helmcache",
-		RepositoryConfig: "/tmp/.helmrepo",
-		Debug:            true,
-		Linting:          true,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	// Add needed chart-repos to the client
-	err = helmClient.AddOrUpdateChartRepo(repo.Entry{
-		Name: "stable",
-		URL:  "https://kubernetes-charts.storage.googleapis.com",
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	// Define the chart you want to install
-	chartSpec := helmclient.ChartSpec{
-		ReleaseName: "etcd-operator",
-		ChartName:   "stable/etcd-operator",
-		Namespace:   "default",
-		UpgradeCRDs: true,
-		Wait:        true,
-	}
-
-	err = helmClient.InstallOrUpgradeChart(&chartSpec)
-	if err != nil {
-		panic(err)
-	}
-}
-```
-
-Alternatively, you can create a client via REST config: 
-```go
-helmClient, err := helmclient.NewClientFromRestConf(&restClientOpts)
-```
-or via Kubeconfig:
-
-```go
-helmClient, err := helmclient.NewClientFromKubeConf()
-```
+An example of this can be found in the corresponding [example](https://pkg.go.dev/github.com/mittwald/go-helm-client?tab=doc#example_HelmClient_AddOrUpdateChartRepo_private).
 
 ## Mock Client
 
@@ -80,17 +31,6 @@ Example usage of the mocked client can be found in [mock/mock_test.go](mock/mock
 
 If you made changes to [interface.go](./interface.go), you should issue the `go generate ./...` command to trigger code generation. 
 
-#### Private chart repository
-When working with private repositories, you can utilize the `Username` and `Password` parameters of a chart entry to specify credentials, e.g.:
-
-```go
-err := helmClient.AddOrUpdateChartRepo(repo.Entry{
-    Name: "stable",
-    URL:  "https://private-chart.somedomain.com",
-    Username: "foo",
-    Password: "bar",
-})
-```
 
 ## Documentation
 For more specific documentation, please refer to the [godoc](https://pkg.go.dev/github.com/mittwald/go-helm-client/) of this library.

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,164 @@
+package helmclient
+
+import (
+	"helm.sh/helm/v3/pkg/repo"
+	"k8s.io/client-go/rest"
+)
+
+func ExampleNew() {
+	opt := &Options{
+		RepositoryCache:  "/tmp/.helmcache",
+		RepositoryConfig: "/tmp/.helmrepo",
+		Debug:            true,
+		Linting:          true,
+	}
+
+	// Construct a new Helm client, where '_' is the constructed client.
+	// Change this empty assignment to get access to the client's services.
+	_, err := New(opt)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ExampleNewClientFromRestConf() {
+	opt := &RestConfClientOptions{
+		Options: &Options{
+			RepositoryCache:  "/tmp/.helmcache",
+			RepositoryConfig: "/tmp/.helmrepo",
+			Debug:            true,
+			Linting:          true,
+		},
+		RestConfig: &rest.Config{},
+	}
+
+	// Construct a new Helm client via REST configuration, where '_' is the constructed client.
+	// Change this empty assignment to get access to the client's services.
+	_, err := NewClientFromRestConf(opt)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ExampleNewClientFromKubeConf() {
+	opt := &KubeConfClientOptions{
+		Options: &Options{
+			RepositoryCache:  "/tmp/.helmcache",
+			RepositoryConfig: "/tmp/.helmrepo",
+			Debug:            true,
+			Linting:          true,
+		},
+		KubeContext: "",
+		KubeConfig:  []byte{},
+	}
+
+	// Construct a new Helm client via KubeConf, where '_' is the constructed client.
+	// Change this empty assignment to get access to the client's services.
+	_, err := NewClientFromKubeConf(opt)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_AddOrUpdateChartRepo_public() {
+	// Dummy assignment
+	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
+	helmClient := &HelmClient{}
+
+	// Define a public chart repository
+	chartRepo := repo.Entry{
+		Name: "stable",
+		URL:  "https://kubernetes-charts.storage.googleapis.com",
+	}
+
+	// Add a chart-repository to the client
+	if err := helmClient.AddOrUpdateChartRepo(chartRepo); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_AddOrUpdateChartRepo_private() {
+	// Dummy assignment
+	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
+	helmClient := &HelmClient{}
+
+	// Define a private chart repository
+	chartRepo := repo.Entry{
+		Name:     "stable",
+		URL:      "https://private-chartrepo.somedomain.com",
+		Username: "foo",
+		Password: "bar",
+	}
+
+	// Add a chart-repository to the client
+	if err := helmClient.AddOrUpdateChartRepo(chartRepo); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_InstallOrUpgradeChart() {
+	// Dummy assignment
+	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
+	helmClient := &HelmClient{}
+
+	// Define the chart to be installed
+	chartSpec := ChartSpec{
+		ReleaseName: "etcd-operator",
+		ChartName:   "stable/etcd-operator",
+		Namespace:   "default",
+		UpgradeCRDs: true,
+		Wait:        true,
+	}
+
+	if err := helmClient.InstallOrUpgradeChart(&chartSpec); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_DeleteChartFromCache() {
+	// Dummy assignment
+	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
+	helmClient := &HelmClient{}
+
+	// Define the chart to be deleted from the client's cache
+	chartSpec := ChartSpec{
+		ReleaseName: "etcd-operator",
+		ChartName:   "stable/etcd-operator",
+		Namespace:   "default",
+		UpgradeCRDs: true,
+		Wait:        true,
+	}
+
+	if err := helmClient.DeleteChartFromCache(&chartSpec); err != nil {
+		panic(err)
+	}
+
+}
+func ExampleHelmClient_UpdateChartRepos() {
+	// Dummy assignment
+	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
+	helmClient := &HelmClient{}
+
+	if err := helmClient.UpdateChartRepos(); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_UninstallRelease() {
+	// Dummy assignment
+	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
+	helmClient := &HelmClient{}
+
+	// Define the released chart to be installed
+	chartSpec := ChartSpec{
+		ReleaseName: "etcd-operator",
+		ChartName:   "stable/etcd-operator",
+		Namespace:   "default",
+		UpgradeCRDs: true,
+		Wait:        true,
+	}
+
+	if err := helmClient.UninstallRelease(&chartSpec); err != nil {
+		panic(err)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -13,8 +13,6 @@ func ExampleNew() {
 		Linting:          true,
 	}
 
-	// Construct a new Helm client, where '_' is the constructed client.
-	// Change this empty assignment to get access to the client's services.
 	helmClient, err := New(opt)
 	if err != nil {
 		panic(err)
@@ -33,12 +31,11 @@ func ExampleNewClientFromRestConf() {
 		RestConfig: &rest.Config{},
 	}
 
-	// Construct a new Helm client via REST configuration, where '_' is the constructed client.
-	// Change this empty assignment to get access to the client's services.
-	_, err := NewClientFromRestConf(opt)
+	helmClient, err := NewClientFromRestConf(opt)
 	if err != nil {
 		panic(err)
 	}
+	_ = helmClient
 }
 
 func ExampleNewClientFromKubeConf() {
@@ -53,12 +50,11 @@ func ExampleNewClientFromKubeConf() {
 		KubeConfig:  []byte{},
 	}
 
-	// Construct a new Helm client via KubeConf, where '_' is the constructed client.
-	// Change this empty assignment to get access to the client's services.
-	_, err := NewClientFromKubeConf(opt)
+	helmClient, err := NewClientFromKubeConf(opt)
 	if err != nil {
 		panic(err)
 	}
+	_ = helmClient
 }
 
 func ExampleHelmClient_AddOrUpdateChartRepo_public() {

--- a/client_test.go
+++ b/client_test.go
@@ -15,10 +15,11 @@ func ExampleNew() {
 
 	// Construct a new Helm client, where '_' is the constructed client.
 	// Change this empty assignment to get access to the client's services.
-	_, err := New(opt)
+	helmClient, err := New(opt)
 	if err != nil {
 		panic(err)
 	}
+	_ = helmClient
 }
 
 func ExampleNewClientFromRestConf() {
@@ -61,10 +62,6 @@ func ExampleNewClientFromKubeConf() {
 }
 
 func ExampleHelmClient_AddOrUpdateChartRepo_public() {
-	// Dummy assignment
-	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
-	helmClient := &HelmClient{}
-
 	// Define a public chart repository
 	chartRepo := repo.Entry{
 		Name: "stable",
@@ -78,10 +75,6 @@ func ExampleHelmClient_AddOrUpdateChartRepo_public() {
 }
 
 func ExampleHelmClient_AddOrUpdateChartRepo_private() {
-	// Dummy assignment
-	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
-	helmClient := &HelmClient{}
-
 	// Define a private chart repository
 	chartRepo := repo.Entry{
 		Name:     "stable",
@@ -97,10 +90,6 @@ func ExampleHelmClient_AddOrUpdateChartRepo_private() {
 }
 
 func ExampleHelmClient_InstallOrUpgradeChart() {
-	// Dummy assignment
-	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
-	helmClient := &HelmClient{}
-
 	// Define the chart to be installed
 	chartSpec := ChartSpec{
 		ReleaseName: "etcd-operator",
@@ -116,10 +105,6 @@ func ExampleHelmClient_InstallOrUpgradeChart() {
 }
 
 func ExampleHelmClient_DeleteChartFromCache() {
-	// Dummy assignment
-	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
-	helmClient := &HelmClient{}
-
 	// Define the chart to be deleted from the client's cache
 	chartSpec := ChartSpec{
 		ReleaseName: "etcd-operator",
@@ -135,20 +120,12 @@ func ExampleHelmClient_DeleteChartFromCache() {
 
 }
 func ExampleHelmClient_UpdateChartRepos() {
-	// Dummy assignment
-	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
-	helmClient := &HelmClient{}
-
 	if err := helmClient.UpdateChartRepos(); err != nil {
 		panic(err)
 	}
 }
 
 func ExampleHelmClient_UninstallRelease() {
-	// Dummy assignment
-	// Construct a real Helm client via New(), NewClientFromRestConf(), or NewClientFromKubeConf()
-	helmClient := &HelmClient{}
-
 	// Define the released chart to be installed
 	chartSpec := ChartSpec{
 		ReleaseName: "etcd-operator",

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,3 @@
+package helmclient
+
+var helmClient *HelmClient

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -6,6 +6,7 @@ package mockhelmclient
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	helmclient "github.com/mittwald/go-helm-client"
 	repo "helm.sh/helm/v3/pkg/repo"
 	reflect "reflect"
 )

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -5,11 +5,9 @@
 package mockhelmclient
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	helmclient "github.com/mittwald/go-helm-client"
 	repo "helm.sh/helm/v3/pkg/repo"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -5,10 +5,11 @@
 package mockhelmclient
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	helmclient "github.com/mittwald/go-helm-client"
 	repo "helm.sh/helm/v3/pkg/repo"
-	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface


### PR DESCRIPTION
- Add Godoc example code for exported functions & methods.
- Remove example code from the README
Solves: #4 