### PR TITLE
made dry run an available flag

### DIFF
--- a/client.go
+++ b/client.go
@@ -586,6 +586,7 @@ func mergeInstallOptions(chartSpec *ChartSpec, installOptions *action.Install) {
 	installOptions.NameTemplate = chartSpec.NameTemplate
 	installOptions.Atomic = chartSpec.Atomic
 	installOptions.SkipCRDs = chartSpec.SkipCRDs
+	installOptions.DryRun = chartSpec.DryRun
 	installOptions.SubNotes = chartSpec.SubNotes
 }
 
@@ -603,6 +604,7 @@ func mergeUpgradeOptions(chartSpec *ChartSpec, upgradeOptions *action.Upgrade) {
 	upgradeOptions.MaxHistory = chartSpec.MaxHistory
 	upgradeOptions.Atomic = chartSpec.Atomic
 	upgradeOptions.CleanupOnFail = chartSpec.CleanupOnFail
+	upgradeOptions.DryRun = chartSpec.DryRun
 	upgradeOptions.SubNotes = chartSpec.SubNotes
 }
 

--- a/types.go
+++ b/types.go
@@ -115,4 +115,7 @@ type ChartSpec struct {
 
 	// +optional
 	CleanupOnFail bool `json:"cleanupOnFail,omitempty"`
+
+	// +optional
+	DryRun bool `json:"dryRun,omitempty"`
 }


### PR DESCRIPTION
This should add the dry run as a pass through to the helm client I think.

TBH I was not sure how to test this locally as I am pretty new to golang and haven't quite figured it totally out yet. Happy to take some feedback.