### PR TITLE
Accept DebugLog func via options

### DIFF
--- a/client.go
+++ b/client.go
@@ -86,14 +86,19 @@ func newClient(options *Options, clientGetter genericclioptions.RESTClientGetter
 		return nil, err
 	}
 
+	debugLog := options.DebugLog
+	if debugLog == nil {
+		debugLog = func(format string, v ...interface{}) {
+			log.Printf(format, v...)
+		}
+	}
+
 	actionConfig := new(action.Configuration)
 	err = actionConfig.Init(
 		clientGetter,
 		settings.Namespace(),
 		os.Getenv("HELM_DRIVER"),
-		func(format string, v ...interface{}) {
-			log.Printf(format, v)
-		},
+		debugLog,
 	)
 	if err != nil {
 		return nil, err

--- a/types.go
+++ b/types.go
@@ -32,6 +32,7 @@ type Options struct {
 	RepositoryCache  string
 	Debug            bool
 	Linting          bool
+	DebugLog         action.DebugLog
 }
 
 // RESTClientGetter defines the values of a helm REST client


### PR DESCRIPTION
This change introduces the ability to pass in a debug log func via `Options` as expected by [action.Configuration.Init](https://pkg.go.dev/helm.sh/helm/v3/pkg/action#Configuration.Init). When no such func is available in `Options`, a func is created that passes through format string and args to standard library `log.Printf`, which is _mostly_ the same as current behavior, although current behavior does not pass through the format args as variadic args (which I assumed was not intentional).