### PR TITLE
add interface functions to list & get releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           set -x
           apt-get -y update && apt-get -y install git
           cd /
-          go get -u github.com/golang/mock/mockgen@v1.4.4
+          go get -u github.com/golang/mock/mockgen@v1.5.0
           cd -
           go env
           go generate ./...

--- a/client_test.go
+++ b/client_test.go
@@ -137,3 +137,21 @@ func ExampleHelmClient_UninstallRelease() {
 		panic(err)
 	}
 }
+
+func ExampleHelmClient_ListDeployedReleases() {
+	if _, err := helmClient.ListDeployedReleases(); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_GetReleaseValues() {
+	if _, err := helmClient.GetReleaseValues("etcd-operator", true); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleHelmClient_GetRelease() {
+	if _, err := helmClient.GetRelease("etcd-operator"); err != nil {
+		panic(err)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -786,8 +786,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -830,8 +828,6 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/interface.go
+++ b/interface.go
@@ -3,6 +3,7 @@ package helmclient
 import (
 	"context"
 
+	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
@@ -12,6 +13,9 @@ type Client interface {
 	AddOrUpdateChartRepo(entry repo.Entry) error
 	UpdateChartRepos() error
 	InstallOrUpgradeChart(ctx context.Context, spec *ChartSpec) error
+	ListDeployedReleases() ([]*release.Release, error)
+	GetRelease(name string) (*release.Release, error)
+	GetReleaseValues(name string, allValues bool) (map[string]interface{}, error)
 	DeleteChartFromCache(spec *ChartSpec) error
 	UninstallRelease(spec *ChartSpec) error
 	TemplateChart(spec *ChartSpec) ([]byte, error)

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -6,36 +6,38 @@ package mockhelmclient
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	helmclient "github.com/mittwald/go-helm-client"
+	release "helm.sh/helm/v3/pkg/release"
 	repo "helm.sh/helm/v3/pkg/repo"
-	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// AddOrUpdateChartRepo mocks base method
+// AddOrUpdateChartRepo mocks base method.
 func (m *MockClient) AddOrUpdateChartRepo(entry repo.Entry) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddOrUpdateChartRepo", entry)
@@ -43,41 +45,13 @@ func (m *MockClient) AddOrUpdateChartRepo(entry repo.Entry) error {
 	return ret0
 }
 
-// AddOrUpdateChartRepo indicates an expected call of AddOrUpdateChartRepo
+// AddOrUpdateChartRepo indicates an expected call of AddOrUpdateChartRepo.
 func (mr *MockClientMockRecorder) AddOrUpdateChartRepo(entry interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdateChartRepo", reflect.TypeOf((*MockClient)(nil).AddOrUpdateChartRepo), entry)
 }
 
-// UpdateChartRepos mocks base method
-func (m *MockClient) UpdateChartRepos() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateChartRepos")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateChartRepos indicates an expected call of UpdateChartRepos
-func (mr *MockClientMockRecorder) UpdateChartRepos() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChartRepos", reflect.TypeOf((*MockClient)(nil).UpdateChartRepos))
-}
-
-// InstallOrUpgradeChart mocks base method
-func (m *MockClient) InstallOrUpgradeChart(ctx context.Context, spec *helmclient.ChartSpec) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallOrUpgradeChart", ctx, spec)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallOrUpgradeChart indicates an expected call of InstallOrUpgradeChart
-func (mr *MockClientMockRecorder) InstallOrUpgradeChart(ctx, spec interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallOrUpgradeChart", reflect.TypeOf((*MockClient)(nil).InstallOrUpgradeChart), ctx, spec)
-}
-
-// DeleteChartFromCache mocks base method
+// DeleteChartFromCache mocks base method.
 func (m *MockClient) DeleteChartFromCache(spec *helmclient.ChartSpec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteChartFromCache", spec)
@@ -85,27 +59,86 @@ func (m *MockClient) DeleteChartFromCache(spec *helmclient.ChartSpec) error {
 	return ret0
 }
 
-// DeleteChartFromCache indicates an expected call of DeleteChartFromCache
+// DeleteChartFromCache indicates an expected call of DeleteChartFromCache.
 func (mr *MockClientMockRecorder) DeleteChartFromCache(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChartFromCache", reflect.TypeOf((*MockClient)(nil).DeleteChartFromCache), spec)
 }
 
-// UninstallRelease mocks base method
-func (m *MockClient) UninstallRelease(spec *helmclient.ChartSpec) error {
+// GetRelease mocks base method.
+func (m *MockClient) GetRelease(name string) (*release.Release, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UninstallRelease", spec)
+	ret := m.ctrl.Call(m, "GetRelease", name)
+	ret0, _ := ret[0].(*release.Release)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelease indicates an expected call of GetRelease.
+func (mr *MockClientMockRecorder) GetRelease(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelease", reflect.TypeOf((*MockClient)(nil).GetRelease), name)
+}
+
+// GetReleaseValues mocks base method.
+func (m *MockClient) GetReleaseValues(name string, allValues bool) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReleaseValues", name, allValues)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReleaseValues indicates an expected call of GetReleaseValues.
+func (mr *MockClientMockRecorder) GetReleaseValues(name, allValues interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseValues", reflect.TypeOf((*MockClient)(nil).GetReleaseValues), name, allValues)
+}
+
+// InstallOrUpgradeChart mocks base method.
+func (m *MockClient) InstallOrUpgradeChart(ctx context.Context, spec *helmclient.ChartSpec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallOrUpgradeChart", ctx, spec)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UninstallRelease indicates an expected call of UninstallRelease
-func (mr *MockClientMockRecorder) UninstallRelease(spec interface{}) *gomock.Call {
+// InstallOrUpgradeChart indicates an expected call of InstallOrUpgradeChart.
+func (mr *MockClientMockRecorder) InstallOrUpgradeChart(ctx, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallRelease", reflect.TypeOf((*MockClient)(nil).UninstallRelease), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallOrUpgradeChart", reflect.TypeOf((*MockClient)(nil).InstallOrUpgradeChart), ctx, spec)
 }
 
-// TemplateChart mocks base method
+// LintChart mocks base method.
+func (m *MockClient) LintChart(spec *helmclient.ChartSpec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LintChart", spec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LintChart indicates an expected call of LintChart.
+func (mr *MockClientMockRecorder) LintChart(spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LintChart", reflect.TypeOf((*MockClient)(nil).LintChart), spec)
+}
+
+// ListDeployedReleases mocks base method.
+func (m *MockClient) ListDeployedReleases() ([]*release.Release, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDeployedReleases")
+	ret0, _ := ret[0].([]*release.Release)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDeployedReleases indicates an expected call of ListDeployedReleases.
+func (mr *MockClientMockRecorder) ListDeployedReleases() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployedReleases", reflect.TypeOf((*MockClient)(nil).ListDeployedReleases))
+}
+
+// TemplateChart mocks base method.
 func (m *MockClient) TemplateChart(spec *helmclient.ChartSpec) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TemplateChart", spec)
@@ -114,22 +147,36 @@ func (m *MockClient) TemplateChart(spec *helmclient.ChartSpec) ([]byte, error) {
 	return ret0, ret1
 }
 
-// TemplateChart indicates an expected call of TemplateChart
+// TemplateChart indicates an expected call of TemplateChart.
 func (mr *MockClientMockRecorder) TemplateChart(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateChart", reflect.TypeOf((*MockClient)(nil).TemplateChart), spec)
 }
 
-// LintChart mocks base method
-func (m *MockClient) LintChart(spec *helmclient.ChartSpec) error {
+// UninstallRelease mocks base method.
+func (m *MockClient) UninstallRelease(spec *helmclient.ChartSpec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LintChart", spec)
+	ret := m.ctrl.Call(m, "UninstallRelease", spec)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// LintChart indicates an expected call of LintChart
-func (mr *MockClientMockRecorder) LintChart(spec interface{}) *gomock.Call {
+// UninstallRelease indicates an expected call of UninstallRelease.
+func (mr *MockClientMockRecorder) UninstallRelease(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LintChart", reflect.TypeOf((*MockClient)(nil).LintChart), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallRelease", reflect.TypeOf((*MockClient)(nil).UninstallRelease), spec)
+}
+
+// UpdateChartRepos mocks base method.
+func (m *MockClient) UpdateChartRepos() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateChartRepos")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateChartRepos indicates an expected call of UpdateChartRepos.
+func (mr *MockClientMockRecorder) UpdateChartRepos() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChartRepos", reflect.TypeOf((*MockClient)(nil).UpdateChartRepos))
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -4,18 +4,57 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"helm.sh/helm/v3/pkg/release"
 )
 
-func TestUpdateChartRepos(t *testing.T) {
+var mockedRelease = release.Release{Name: "test"}
+
+// TestHelmClientInterfaces performs checks on the clients interface functions.
+func TestHelmClientInterfaces(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockClient := NewMockClient(ctrl)
 
 	t.Run("UpdateChartRepos", func(t *testing.T) {
-		mockClient.EXPECT().UpdateChartRepos()
+		mockClient.EXPECT().UpdateChartRepos().Return(nil)
 		err := mockClient.UpdateChartRepos()
 		if err != nil {
+			panic(err)
+		}
+	})
+
+	t.Run("ListReleases", func(t *testing.T) {
+		mockClient.EXPECT().ListDeployedReleases().Return([]*release.Release{&mockedRelease}, nil)
+		r, err := mockClient.ListDeployedReleases()
+		if err != nil {
+			panic(err)
+		}
+		if r == nil || len(r) == 0 {
+			panic(err)
+		}
+	})
+
+	t.Run("GetRelease", func(t *testing.T) {
+		mockClient.EXPECT().GetRelease(mockedRelease.Name).Return(&release.Release{Name: mockedRelease.Name}, nil)
+		r, err := mockClient.GetRelease(mockedRelease.Name)
+		if err != nil {
+			panic(err)
+		}
+		if r == nil {
+			panic(err)
+		}
+	})
+
+	t.Run("GetReleaseValues", func(t *testing.T) {
+		m := make(map[string]interface{})
+		mockClient.EXPECT().GetReleaseValues(mockedRelease.Name, true).
+			Return(m, nil)
+		rv, err := mockClient.GetReleaseValues(mockedRelease.Name, true)
+		if err != nil {
+			panic(err)
+		}
+		if rv == nil {
 			panic(err)
 		}
 	})

--- a/types.go
+++ b/types.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"helm.sh/helm/v3/pkg/getter"
-
 	"k8s.io/client-go/rest"
 
 	"helm.sh/helm/v3/pkg/action"


### PR DESCRIPTION
Fixes #23 

This PR adds functionality to
- list (deployed) releases (`helm ls`),
- get individual releases (`helm get all <release>`),
- get individual release values (`helm get values <release> -a`).

Code examples & mock tests have been added aswell.