### PR TITLE
Add ListReleaseHistory func

### DIFF
--- a/client.go
+++ b/client.go
@@ -500,8 +500,19 @@ func (c *HelmClient) LintChart(spec *ChartSpec) error {
 	return c.lint(chartPath, values)
 }
 
+// SetDebugLog set's a Helm client's DebugLog to the desired 'debugLog'.
 func (c *HelmClient) SetDebugLog(debugLog action.DebugLog) {
 	c.DebugLog = debugLog
+}
+
+// ListReleaseHistory lists the last 'max' number of entries
+// in the history of the release identified by 'name'.
+func (c *HelmClient) ListReleaseHistory(name string, max int) ([]*release.Release, error) {
+	client := action.NewHistory(c.ActionConfig)
+
+	client.Max = max
+
+	return client.Run(name)
 }
 
 // upgradeCRDs upgrades the CRDs of the provided chart
@@ -682,9 +693,7 @@ func (c *HelmClient) getChart(chartName string, chartPathOptions *action.ChartPa
 
 // chartIsInstalled checks whether a chart is already installed or not by the provided release name
 func (c *HelmClient) chartIsInstalled(release string) (bool, error) {
-	histClient := action.NewHistory(c.ActionConfig)
-	histClient.Max = 1
-	if _, err := histClient.Run(release); err == driver.ErrReleaseNotFound {
+	if _, err := c.ListReleaseHistory(release, 1); err == driver.ErrReleaseNotFound {
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/client_getter.go
+++ b/client_getter.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// NewRESTClientGetter
+// NewRESTClientGetter returns a RESTClientGetter using the provided 'namespace', 'kubeConfig' and 'restConfig'.
 //
 // source: https://github.com/helm/helm/issues/6910#issuecomment-601277026
 func NewRESTClientGetter(namespace string, kubeConfig []byte, restConfig *rest.Config) *RESTClientGetter {
@@ -29,15 +29,16 @@ func (c *RESTClientGetter) ToRESTConfig() (*rest.Config, error) {
 	return clientcmd.RESTConfigFromKubeConfig(c.kubeConfig)
 }
 
+// ToDiscoveryClient returns a CachedDiscoveryInterface that can be used as a discovery client.
 func (c *RESTClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	config, err := c.ToRESTConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	// The more groups you have, the more discovery requests you need to make.
-	// given 25 groups (our groups + a few custom conf) with one-ish version each, discovery needs to make 50 requests
-	// double it just so we don't end up here again for a while.  This config is only used for discovery.
+	// The more API groups exist, the more discovery requests need to be made.
+	// Given 25 API groups with about one version each, discovery needs to make 50 requests.
+	// This setting is only used for discovery.
 	config.Burst = 100
 
 	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(config)

--- a/interface.go
+++ b/interface.go
@@ -10,6 +10,7 @@ import (
 
 //go:generate mockgen -source=interface.go -package mockhelmclient -destination=./mock/interface.go -self_package=. Client
 
+// Client holds the method signatures for a Helm client.
 type Client interface {
 	AddOrUpdateChartRepo(entry repo.Entry) error
 	UpdateChartRepos() error
@@ -23,4 +24,5 @@ type Client interface {
 	TemplateChart(spec *ChartSpec) ([]byte, error)
 	LintChart(spec *ChartSpec) error
 	SetDebugLog(debugLog action.DebugLog)
+	ListReleaseHistory(name string, max int) ([]*release.Release, error)
 }

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -126,6 +126,21 @@ func (mr *MockClientMockRecorder) ListDeployedReleases() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployedReleases", reflect.TypeOf((*MockClient)(nil).ListDeployedReleases))
 }
 
+// ListReleaseHistory mocks base method.
+func (m *MockClient) ListReleaseHistory(name string, max int) ([]*release.Release, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListReleaseHistory", name, max)
+	ret0, _ := ret[0].([]*release.Release)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListReleaseHistory indicates an expected call of ListReleaseHistory.
+func (mr *MockClientMockRecorder) ListReleaseHistory(name, max interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReleaseHistory", reflect.TypeOf((*MockClient)(nil).ListReleaseHistory), name, max)
+}
+
 // RollbackRelease mocks base method.
 func (m *MockClient) RollbackRelease(spec *helmclient.ChartSpec, version int) error {
 	m.ctrl.T.Helper()

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -15,6 +15,9 @@ func TestHelmClientInterfaces(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockClient := NewMockClient(ctrl)
+	if mockClient == nil {
+		t.Fail()
+	}
 
 	t.Run("UpdateChartRepos", func(t *testing.T) {
 		mockClient.EXPECT().UpdateChartRepos().Return(nil)


### PR DESCRIPTION
This PR adds a new function `ListReleaseHistory()` to the client, enabling users to print (a configurable amount of) historical revisions for a release.

Fixes #37 