### PR TITLE
Use release name from spec in Teplate

### DIFF
--- a/client.go
+++ b/client.go
@@ -407,7 +407,7 @@ func (c *HelmClient) TemplateChart(spec *ChartSpec) ([]byte, error) {
 	mergeInstallOptions(spec, client)
 
 	client.DryRun = true
-	client.ReleaseName = "RELEASE-NAME"
+	client.ReleaseName = spec.ReleaseName
 	client.Replace = true // Skip the name check
 	client.ClientOnly = true
 	client.APIVersions = []string{}


### PR DESCRIPTION
The actual version does not replace the release name in template