### PR TITLE
Allow optional chart installation check behavior

### DIFF
--- a/types.go
+++ b/types.go
@@ -29,13 +29,16 @@ type RestConfClientOptions struct {
 
 // Options defines the options of a client.
 type Options struct {
-	Namespace        string
-	RepositoryConfig string
-	RepositoryCache  string
-	Debug            bool
-	Linting          bool
-	DebugLog         action.DebugLog
+	Namespace           string
+	RepositoryConfig    string
+	RepositoryCache     string
+	Debug               bool
+	Linting             bool
+	DebugLog            action.DebugLog
+	CheckChartInstalled CheckChartInstalledFunc
 }
+
+type CheckChartInstalledFunc func(*ChartSpec) (bool, error)
 
 // RESTClientGetter defines the values of a helm REST client.
 type RESTClientGetter struct {
@@ -51,9 +54,10 @@ type HelmClient struct {
 	Providers getter.Providers
 	storage   *repo.File
 	// ActionConfig is the helm action configuration.
-	ActionConfig *action.Configuration
-	linting      bool
-	DebugLog     action.DebugLog
+	ActionConfig        *action.Configuration
+	linting             bool
+	DebugLog            action.DebugLog
+	CheckChartInstalled CheckChartInstalledFunc
 }
 
 // ChartSpec defines the values of a helm chart


### PR DESCRIPTION
We (folks at RStudio) are finding that in cases where a previous release is in a state other than `deployed` that the existing check can result in an irrecoverable state where `InstallOrUpgradeChart` will always assume an _install_ is needed, but the helm library code will fail with `cannot re-use a name that is still in use`. Rather than force a new behavior on all users of this library, I'm opting for a pluggable behavior change at the place where the existing behavior is a problem for us, with the intention that we will inject a `CheckChartInstalled` function that meets our needs. Feedback very much appreciated ❤️ 