### PR TITLE
Use chart version from ChartSpec in LintChart

### DIFF
--- a/client.go
+++ b/client.go
@@ -479,7 +479,9 @@ func (c *HelmClient) TemplateChart(spec *ChartSpec) ([]byte, error) {
 
 // LintChart fetches a chart using the provided ChartSpec 'spec' and lints it's values.
 func (c *HelmClient) LintChart(spec *ChartSpec) error {
-	_, chartPath, err := c.getChart(spec.ChartName, &action.ChartPathOptions{})
+	_, chartPath, err := c.getChart(spec.ChartName, &action.ChartPathOptions{
+		Version: spec.Version,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For some reason, a chart version was not passed to `ChartPathOptions` in `LintChart`. It worked fine with local charts. However, if somebody wants to lint a specific helm chart from a remote repository, the last version downloads and the passed version number is ignored.