### PR TITLE
Added WaitForJobs to ChartSpec

### DIFF
--- a/client.go
+++ b/client.go
@@ -776,6 +776,7 @@ func mergeRollbackOptions(chartSpec *ChartSpec, rollbackOptions *action.Rollback
 	rollbackOptions.MaxHistory = chartSpec.MaxHistory
 	rollbackOptions.Recreate = chartSpec.Recreate
 	rollbackOptions.Wait = chartSpec.Wait
+	rollbackOptions.WaitForJobs = chartSpec.WaitForJobs
 }
 
 // mergeInstallOptions merges values of the provided chart to helm install options used by the client.
@@ -795,6 +796,7 @@ func mergeInstallOptions(chartSpec *ChartSpec, installOptions *action.Install) {
 	installOptions.SkipCRDs = chartSpec.SkipCRDs
 	installOptions.DryRun = chartSpec.DryRun
 	installOptions.SubNotes = chartSpec.SubNotes
+	installOptions.WaitForJobs = chartSpec.WaitForJobs
 }
 
 // mergeUpgradeOptions merges values of the provided chart to helm upgrade options used by the client.
@@ -813,6 +815,7 @@ func mergeUpgradeOptions(chartSpec *ChartSpec, upgradeOptions *action.Upgrade) {
 	upgradeOptions.CleanupOnFail = chartSpec.CleanupOnFail
 	upgradeOptions.DryRun = chartSpec.DryRun
 	upgradeOptions.SubNotes = chartSpec.SubNotes
+	upgradeOptions.WaitForJobs = chartSpec.WaitForJobs
 }
 
 // mergeUninstallReleaseOptions merges values of the provided chart to helm uninstall options used by the client.

--- a/types.go
+++ b/types.go
@@ -85,9 +85,9 @@ type ChartSpec struct {
 	// Wait indicates whether to wait for the release to be deployed or not.
 	// +optional
 	Wait bool `json:"wait,omitempty"`
-	// WaitForJobs if set and Wait enabled, will wait until all Jobs have
-	// been completed before marking the release as successful. It will wait
-	// for as long as Timeout
+	// WaitForJobs indicates whether to wait for completion of release Jobs before marking the release as successful.
+	// 'Wait' has to be specified for this to take effect.
+	// The timeout may be specified via the 'Timeout' field.
 	WaitForJobs bool `json:"waitForJobs,omitempty"`
 	// DependencyUpdate indicates whether to update the chart release if the dependencies have changed.
 	// +optional

--- a/types.go
+++ b/types.go
@@ -85,6 +85,10 @@ type ChartSpec struct {
 	// Wait indicates whether to wait for the release to be deployed or not.
 	// +optional
 	Wait bool `json:"wait,omitempty"`
+	// WaitForJobs if set and Wait enabled, will wait until all Jobs have
+	// been completed before marking the release as successful. It will wait
+	// for as long as Timeout
+	WaitForJobs bool `json:"waitForJobs,omitempty"`
 	// DependencyUpdate indicates whether to update the chart release if the dependencies have changed.
 	// +optional
 	DependencyUpdate bool `json:"dependencyUpdate,omitempty"`


### PR DESCRIPTION
If set and `Wait` enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as `Timeout`