### PR TITLE
allow specifying a custom rollback function

### DIFF
--- a/client.go
+++ b/client.go
@@ -247,7 +247,7 @@ func (c *HelmClient) GetRelease(name string) (*release.Release, error) {
 	return c.getRelease(name)
 }
 
-// RollbackRelease implicity rolls back a release to the last revision.
+// RollbackRelease implicitly rolls back a release to the last revision.
 func (c *HelmClient) RollbackRelease(spec *ChartSpec) error {
 	return c.rollbackRelease(spec)
 }
@@ -783,7 +783,7 @@ func (c *HelmClient) getRelease(name string) (*release.Release, error) {
 	return getReleaseClient.Run(name)
 }
 
-// rollbackRelease implicity rolls back a release to the last revision.
+// rollbackRelease implicitly rolls back a release to the last revision.
 func (c *HelmClient) rollbackRelease(spec *ChartSpec) error {
 	client := action.NewRollback(c.ActionConfig)
 

--- a/interface.go
+++ b/interface.go
@@ -21,7 +21,8 @@ type Client interface {
 	ListDeployedReleases() ([]*release.Release, error)
 	ListReleasesByStateMask(action.ListStates) ([]*release.Release, error)
 	GetRelease(name string) (*release.Release, error)
-	RollbackRelease(spec *ChartSpec, version int) error
+	// RollBack is an interface to abstract a rollback action.
+	RollBack
 	GetReleaseValues(name string, allValues bool) (map[string]interface{}, error)
 	UninstallRelease(spec *ChartSpec) error
 	UninstallReleaseByName(name string) error
@@ -29,4 +30,8 @@ type Client interface {
 	LintChart(spec *ChartSpec) error
 	SetDebugLog(debugLog action.DebugLog)
 	ListReleaseHistory(name string, max int) ([]*release.Release, error)
+}
+
+type RollBack interface {
+	RollbackRelease(spec *ChartSpec) error
 }

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -172,17 +172,17 @@ func (mr *MockClientMockRecorder) ListReleasesByStateMask(arg0 interface{}) *gom
 }
 
 // RollbackRelease mocks base method.
-func (m *MockClient) RollbackRelease(spec *helmclient.ChartSpec, version int) error {
+func (m *MockClient) RollbackRelease(spec *helmclient.ChartSpec) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RollbackRelease", spec, version)
+	ret := m.ctrl.Call(m, "RollbackRelease", spec)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RollbackRelease indicates an expected call of RollbackRelease.
-func (mr *MockClientMockRecorder) RollbackRelease(spec, version interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) RollbackRelease(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackRelease", reflect.TypeOf((*MockClient)(nil).RollbackRelease), spec, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackRelease", reflect.TypeOf((*MockClient)(nil).RollbackRelease), spec)
 }
 
 // SetDebugLog mocks base method.
@@ -267,4 +267,41 @@ func (m *MockClient) UpgradeChart(ctx context.Context, spec *helmclient.ChartSpe
 func (mr *MockClientMockRecorder) UpgradeChart(ctx, spec, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeChart", reflect.TypeOf((*MockClient)(nil).UpgradeChart), ctx, spec, opts)
+}
+
+// MockRollBack is a mock of RollBack interface.
+type MockRollBack struct {
+	ctrl     *gomock.Controller
+	recorder *MockRollBackMockRecorder
+}
+
+// MockRollBackMockRecorder is the mock recorder for MockRollBack.
+type MockRollBackMockRecorder struct {
+	mock *MockRollBack
+}
+
+// NewMockRollBack creates a new mock instance.
+func NewMockRollBack(ctrl *gomock.Controller) *MockRollBack {
+	mock := &MockRollBack{ctrl: ctrl}
+	mock.recorder = &MockRollBackMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRollBack) EXPECT() *MockRollBackMockRecorder {
+	return m.recorder
+}
+
+// RollbackRelease mocks base method.
+func (m *MockRollBack) RollbackRelease(spec *helmclient.ChartSpec) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RollbackRelease", spec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RollbackRelease indicates an expected call of RollbackRelease.
+func (mr *MockRollBackMockRecorder) RollbackRelease(spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackRelease", reflect.TypeOf((*MockRollBack)(nil).RollbackRelease), spec)
 }

--- a/types.go
+++ b/types.go
@@ -63,6 +63,7 @@ type HelmClient struct {
 
 type GenericHelmOptions struct {
 	PostRenderer postrender.PostRenderer
+	RollBack     RollBack
 }
 
 //go:generate controller-gen object object:headerFile="./hack/boilerplate.go.txt" paths="./..." output:dir=.


### PR DESCRIPTION
This PR adds a `RollBack` field to `GenericHelmOptions`, enabling users to either use the upstream `HelmClient` or a custom type implementing `RollbackRelease` as a rollback strategy.