### PR TITLE
add options for customize the Discovery client's config

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,14 +49,14 @@ func New(options *Options) (Client, error) {
 	return newClient(options, settings.RESTClientGetter(), settings)
 }
 
-// NewClientFromKubeConf returns a new Helm client constructed with the provided kubeconfig options.
-func NewClientFromKubeConf(options *KubeConfClientOptions) (Client, error) {
+// NewClientFromKubeConf returns a new Helm client constructed with the provided kubeconfig & RESTClient (optional) options.
+func NewClientFromKubeConf(options *KubeConfClientOptions, restClientOpts ...RESTClientOption) (Client, error) {
 	settings := cli.New()
 	if options.KubeConfig == nil {
 		return nil, fmt.Errorf("kubeconfig missing")
 	}
 
-	clientGetter := NewRESTClientGetter(options.Namespace, options.KubeConfig, nil)
+	clientGetter := NewRESTClientGetter(options.Namespace, options.KubeConfig, nil, restClientOpts...)
 
 	if options.KubeContext != "" {
 		settings.KubeContext = options.KubeContext

--- a/client_test.go
+++ b/client_test.go
@@ -68,7 +68,7 @@ func ExampleNewClientFromKubeConf() {
 		KubeConfig:  []byte{},
 	}
 
-	helmClient, err := NewClientFromKubeConf(opt)
+	helmClient, err := NewClientFromKubeConf(opt, Burst(100), Timeout(10e9))
 	if err != nil {
 		panic(err)
 	}

--- a/types.go
+++ b/types.go
@@ -42,8 +42,7 @@ type Options struct {
 	Output           io.Writer
 }
 
-// RESTClientGetter defines the options to customsize the RESTClient when
-// call  created
+// RESTClientOption is a function that can be used to set the RESTClientOptions of a HelmClient.
 type RESTClientOption func(*rest.Config)
 
 // The maximum length of time to wait before giving up on a server request

--- a/types.go
+++ b/types.go
@@ -45,8 +45,10 @@ type Options struct {
 // RESTClientOption is a function that can be used to set the RESTClientOptions of a HelmClient.
 type RESTClientOption func(*rest.Config)
 
-// The maximum length of time to wait before giving up on a server request
-// the created RESTClient will use DefaultTimeout: 32s
+// Timeout specifies the timeout for a RESTClient as a RESTClientOption.
+// The default (if unspecified) is 32 seconds.
+// See [1] for reference.
+// [^1]: https://github.com/kubernetes/client-go/blob/c6bd30b9ec5f668df191bc268c6f550c37726edb/discovery/discovery_client.go#L52
 func Timeout(d time.Duration) RESTClientOption {
 	return func(r *rest.Config) {
 		r.Timeout = d

--- a/types.go
+++ b/types.go
@@ -42,11 +42,33 @@ type Options struct {
 	Output           io.Writer
 }
 
+// RESTClientGetter defines the options to customsize the RESTClient when
+// call  created
+type RESTClientOption func(*rest.Config)
+
+// The maximum length of time to wait before giving up on a server request
+// the created RESTClient will use DefaultTimeout: 32s
+func Timeout(d time.Duration) RESTClientOption {
+	return func(r *rest.Config) {
+		r.Timeout = d
+	}
+}
+
+// Maximum burst for throttle
+// the created RESTClient will use DefaultBurst: 100.
+func Burst(v int) RESTClientOption {
+	return func(r *rest.Config) {
+		r.Burst = v
+	}
+}
+
 // RESTClientGetter defines the values of a helm REST client.
 type RESTClientGetter struct {
 	namespace  string
 	kubeConfig []byte
 	restConfig *rest.Config
+
+	opts []RESTClientOption
 }
 
 // HelmClient Client defines the values of a helm client.


### PR DESCRIPTION
when the network status is poor, the default timeout(32s) is not good, so add options for customize the RESTClient's config
Signed-off-by: Gang Liu <gang.liu@daocloud.io>