### PR TITLE
avoid blocking rollbacks when an upgrade fails

### DIFF
--- a/client.go
+++ b/client.go
@@ -391,7 +391,7 @@ func (c *HelmClient) upgrade(ctx context.Context, spec *ChartSpec, opts *Generic
 
 	upgradedRelease, upgradeErr := client.RunWithContext(ctx, spec.ReleaseName, helmChart, values)
 	if upgradeErr != nil {
-		if upgradedRelease != nil && opts != nil && opts.RollBack != nil {
+		if upgradedRelease == nil && opts != nil && opts.RollBack != nil {
 			return nil, opts.RollBack.RollbackRelease(spec)
 		}
 		return nil, upgradeErr


### PR DESCRIPTION
As of now, any rollback after a failed upgrade would be blocked by an erronous condition expecting the release _not_ to be nil when it should be.