### PR TITLE
add template options for kube version and api versions

### DIFF
--- a/client.go
+++ b/client.go
@@ -450,7 +450,7 @@ func (c *HelmClient) lint(chartPath string, values map[string]interface{}) error
 }
 
 // TemplateChart returns a rendered version of the provided ChartSpec 'spec' by performing a "dry-run" install.
-func (c *HelmClient) TemplateChart(spec *ChartSpec) ([]byte, error) {
+func (c *HelmClient) TemplateChart(spec *ChartSpec, options *HelmTemplateOptions) ([]byte, error) {
 	client := action.NewInstall(c.ActionConfig)
 	mergeInstallOptions(spec, client)
 
@@ -458,8 +458,12 @@ func (c *HelmClient) TemplateChart(spec *ChartSpec) ([]byte, error) {
 	client.ReleaseName = spec.ReleaseName
 	client.Replace = true // Skip the name check
 	client.ClientOnly = true
-	client.APIVersions = []string{}
 	client.IncludeCRDs = true
+
+	if options != nil {
+		client.KubeVersion = options.KubeVersion
+		client.APIVersions = options.APIVersions
+	}
 
 	// NameAndChart returns either the TemplateName if set,
 	// the ReleaseName if set or the generatedName as the first return value.

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package helmclient
 import (
 	"bytes"
 	"context"
+	"helm.sh/helm/v3/pkg/chartutil"
 
 	"helm.sh/helm/v3/pkg/action"
 
@@ -257,7 +258,18 @@ func ExampleHelmClient_TemplateChart() {
   backupOperator: false`,
 	}
 
-	_, err := helmClient.TemplateChart(&chartSpec)
+	options := &HelmTemplateOptions{
+		KubeVersion: &chartutil.KubeVersion{
+			Version: "v1.23.10",
+			Major:   "1",
+			Minor:   "23",
+		},
+		APIVersions: []string{
+			"helm.sh/v1/Test",
+		},
+	}
+
+	_, err := helmClient.TemplateChart(&chartSpec, options)
 	if err != nil {
 		panic(err)
 	}

--- a/interface.go
+++ b/interface.go
@@ -27,7 +27,7 @@ type Client interface {
 	GetReleaseValues(name string, allValues bool) (map[string]interface{}, error)
 	UninstallRelease(spec *ChartSpec) error
 	UninstallReleaseByName(name string) error
-	TemplateChart(spec *ChartSpec) ([]byte, error)
+	TemplateChart(spec *ChartSpec, options *HelmTemplateOptions) ([]byte, error)
 	LintChart(spec *ChartSpec) error
 	SetDebugLog(debugLog action.DebugLog)
 	ListReleaseHistory(name string, max int) ([]*release.Release, error)

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -215,18 +215,18 @@ func (mr *MockClientMockRecorder) SetDebugLog(debugLog interface{}) *gomock.Call
 }
 
 // TemplateChart mocks base method.
-func (m *MockClient) TemplateChart(spec *helmclient.ChartSpec) ([]byte, error) {
+func (m *MockClient) TemplateChart(spec *helmclient.ChartSpec, options helmclient.HelmTemplateOptions) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TemplateChart", spec)
+	ret := m.ctrl.Call(m, "TemplateChart", spec, options)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TemplateChart indicates an expected call of TemplateChart.
-func (mr *MockClientMockRecorder) TemplateChart(spec interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) TemplateChart(spec, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateChart", reflect.TypeOf((*MockClient)(nil).TemplateChart), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateChart", reflect.TypeOf((*MockClient)(nil).TemplateChart), spec, options)
 }
 
 // UninstallRelease mocks base method.

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -215,7 +215,7 @@ func (mr *MockClientMockRecorder) SetDebugLog(debugLog interface{}) *gomock.Call
 }
 
 // TemplateChart mocks base method.
-func (m *MockClient) TemplateChart(spec *helmclient.ChartSpec, options helmclient.HelmTemplateOptions) ([]byte, error) {
+func (m *MockClient) TemplateChart(spec *helmclient.ChartSpec, options *helmclient.HelmTemplateOptions) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TemplateChart", spec, options)
 	ret0, _ := ret[0].([]byte)

--- a/types.go
+++ b/types.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/repo"
 )
@@ -88,6 +89,12 @@ type HelmClient struct {
 type GenericHelmOptions struct {
 	PostRenderer postrender.PostRenderer
 	RollBack     RollBack
+}
+
+type HelmTemplateOptions struct {
+	KubeVersion *chartutil.KubeVersion
+	// APIVersions defined here will be appended to the default list helm provides
+	APIVersions chartutil.VersionSet
 }
 
 //go:generate controller-gen object paths="./..." output:dir=.


### PR DESCRIPTION
Allows passing the Kubernetes version and available APIs when templating. Many charts will look at this information to decide what api versions to render ([example](https://github.com/aws/karpenter/blob/v0.17.0/charts/karpenter/templates/_helpers.tpl#L69)).