### PR TITLE
Use values options for additional settings

### DIFF
--- a/client.go
+++ b/client.go
@@ -320,7 +320,8 @@ func (c *HelmClient) install(ctx context.Context, spec *ChartSpec, opts *Generic
 		return nil, err
 	}
 
-	values, err := spec.GetValuesMap()
+	p := getter.All(c.Settings)
+	values, err := spec.GetValuesMap(p)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +370,8 @@ func (c *HelmClient) upgrade(ctx context.Context, spec *ChartSpec, opts *Generic
 		return nil, err
 	}
 
-	values, err := spec.GetValuesMap()
+	p := getter.All(c.Settings)
+	values, err := spec.GetValuesMap(p)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +504,8 @@ func (c *HelmClient) TemplateChart(spec *ChartSpec, options *HelmTemplateOptions
 		return nil, err
 	}
 
-	values, err := spec.GetValuesMap()
+	p := getter.All(c.Settings)
+	values, err := spec.GetValuesMap(p)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +541,8 @@ func (c *HelmClient) LintChart(spec *ChartSpec) error {
 		return err
 	}
 
-	values, err := spec.GetValuesMap()
+	p := getter.All(c.Settings)
+	values, err := spec.GetValuesMap(p)
 	if err != nil {
 		return err
 	}

--- a/spec.go
+++ b/spec.go
@@ -1,17 +1,45 @@
 package helmclient
 
 import (
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/getter"
 	"sigs.k8s.io/yaml"
 )
 
-// GetValuesMap returns the mapped out values of a chart
-func (spec *ChartSpec) GetValuesMap() (map[string]interface{}, error) {
-	var values map[string]interface{}
+// GetValuesMap returns the merged mapped out values of a chart,
+// using both ValuesYaml and ValuesOptions
+func (spec *ChartSpec) GetValuesMap(p getter.Providers) (map[string]interface{}, error) {
+	valuesYaml := map[string]interface{}{}
 
-	err := yaml.Unmarshal([]byte(spec.ValuesYaml), &values)
+	err := yaml.Unmarshal([]byte(spec.ValuesYaml), &valuesYaml)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to Parse ValuesYaml")
 	}
 
-	return values, nil
+	valuesOptions, err := spec.ValuesOptions.MergeValues(p)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to Parse ValuesOptions")
+	}
+
+	return mergeMaps(valuesYaml, valuesOptions), nil
+}
+
+// Copied from https://github.com/helm/helm/blob/ced54b12896ae933017782e2bbd722e2bc8c0914/pkg/cli/values/options.go#L99
+func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = mergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,61 @@
+package helmclient
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeValues(t *testing.T) {
+	nestedMap := map[string]interface{}{
+		"foo": "bar",
+		"baz": map[string]string{
+			"cool": "stuff",
+		},
+	}
+	anotherNestedMap := map[string]interface{}{
+		"foo": "bar",
+		"baz": map[string]string{
+			"cool":    "things",
+			"awesome": "stuff",
+		},
+	}
+	flatMap := map[string]interface{}{
+		"foo": "bar",
+		"baz": "stuff",
+	}
+	anotherFlatMap := map[string]interface{}{
+		"testing": "fun",
+	}
+
+	testMap := mergeMaps(flatMap, nestedMap)
+	equal := reflect.DeepEqual(testMap, nestedMap)
+	if !equal {
+		t.Errorf("Expected a nested map to overwrite a flat value. Expected: %v, got %v", nestedMap, testMap)
+	}
+
+	testMap = mergeMaps(nestedMap, flatMap)
+	equal = reflect.DeepEqual(testMap, flatMap)
+	if !equal {
+		t.Errorf("Expected a flat value to overwrite a map. Expected: %v, got %v", flatMap, testMap)
+	}
+
+	testMap = mergeMaps(nestedMap, anotherNestedMap)
+	equal = reflect.DeepEqual(testMap, anotherNestedMap)
+	if !equal {
+		t.Errorf("Expected a nested map to overwrite another nested map. Expected: %v, got %v", anotherNestedMap, testMap)
+	}
+
+	testMap = mergeMaps(anotherFlatMap, anotherNestedMap)
+	expectedMap := map[string]interface{}{
+		"testing": "fun",
+		"foo":     "bar",
+		"baz": map[string]string{
+			"cool":    "things",
+			"awesome": "stuff",
+		},
+	}
+	equal = reflect.DeepEqual(testMap, expectedMap)
+	if !equal {
+		t.Errorf("Expected a map with different keys to merge properly with another map. Expected: %v, got %v", expectedMap, testMap)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -12,6 +12,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
@@ -113,6 +114,9 @@ type ChartSpec struct {
 	// and https://github.com/kubernetes-sigs/controller-tools/pull/317
 	// +optional
 	ValuesYaml string `json:"valuesYaml,omitempty"`
+	// Specify values similar to the cli
+	// +optional
+	ValuesOptions values.Options `json:"valuesOptions,omitempty"`
 	// Version of the chart release.
 	// +optional
 	Version string `json:"version,omitempty"`


### PR DESCRIPTION
Resolves: #118 

Allows setting the values in various ways, like what's available in the cli, while maintaining ValuesYaml
```go
	spec := ChartSpec{
		...
		ValuesOptions: values.Options{
			// -f/--values
			ValueFiles:   []string{"/path/to/file"},
			// --set-string
			StringValues: []string{"foo=bar", "cool=value"},
			// --set
			Values:       []string{"awesome=stuff,nice=things"},
			// --set-file
			FileValues:   []string{"file=/path/to/file"},
			// --set-json
			JSONValues:   []string{`jsonvalue={"key1":"value1"}`},
		},
	}
```