### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Adds the ability to update both the `go.mod` dependencies as well as the github actions that are used by this repo.

https://github.com/mittwald/go-helm-client/pull/132 removed the dependabot configuration originally and I'm not sure why it is a very useful tool.