### PR TITLE
add missing options for action.Uninstall

### DIFF
--- a/client.go
+++ b/client.go
@@ -911,4 +911,8 @@ func mergeUpgradeOptions(chartSpec *ChartSpec, upgradeOptions *action.Upgrade) {
 func mergeUninstallReleaseOptions(chartSpec *ChartSpec, uninstallReleaseOptions *action.Uninstall) {
 	uninstallReleaseOptions.DisableHooks = chartSpec.DisableHooks
 	uninstallReleaseOptions.Timeout = chartSpec.Timeout
+	uninstallReleaseOptions.DryRun = chartSpec.DryRun
+	uninstallReleaseOptions.Description = chartSpec.Description
+	uninstallReleaseOptions.KeepHistory = chartSpec.KeepHistory
+	uninstallReleaseOptions.Wait = chartSpec.Wait
 }

--- a/client_test.go
+++ b/client_test.go
@@ -288,8 +288,9 @@ func ExampleHelmClient_UninstallRelease() {
 		ReleaseName: "etcd-operator",
 		ChartName:   "stable/etcd-operator",
 		Namespace:   "default",
-		UpgradeCRDs: true,
 		Wait:        true,
+		DryRun:      true,
+		KeepHistory: true,
 	}
 
 	// Uninstall the chart release.

--- a/types.go
+++ b/types.go
@@ -182,4 +182,10 @@ type ChartSpec struct {
 	// DryRun indicates whether to perform a dry run.
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"`
+	// Description specifies a custom description for the uninstalled release
+	// +optional
+	Description string `json:"description,omitempty"`
+	// KeepHistory indicates whether to retain or purge the release history during uninstall
+	// +optional
+	KeepHistory bool `json:"keepHistory,omitempty"`
 }


### PR DESCRIPTION
I have noticed that the `DryRun` option is not applied when calling the `UninstallRelease` function.
I have also added some other available options.

- update example for Uninstall
- add `Description` for completeness but exclude it from example
- remove `UpgradeCRDs` from example, because it is not an option of action.Uninstall