### PR TITLE
fix(client.go): fixes premature index file download

### DIFF
--- a/client.go
+++ b/client.go
@@ -175,16 +175,16 @@ func (c *HelmClient) AddOrUpdateChartRepo(entry repo.Entry) error {
 
 	chartRepo.CachePath = c.Settings.RepositoryCache
 
+	if c.storage.Has(entry.Name) {
+		c.DebugLog("WARNING: repository name %q already exists", entry.Name)
+		return nil
+	}
+
 	if !registry.IsOCI(entry.URL) {
 		_, err = chartRepo.DownloadIndexFile()
 		if err != nil {
 			return err
 		}
-	}
-
-	if c.storage.Has(entry.Name) {
-		c.DebugLog("WARNING: repository name %q already exists", entry.Name)
-		return nil
 	}
 
 	c.storage.Update(&entry)


### PR DESCRIPTION
now when calling `AddOrUpdateChartRepo` the index file is downloaded only when the repo is not already cached in storage.