### PR TITLE
remove pkg/errors import in favour of stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/mittwald/go-helm-client
 go 1.22.0
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/mock v0.4.0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
@@ -97,6 +96,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc6 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/spec.go
+++ b/spec.go
@@ -1,7 +1,8 @@
 package helmclient
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"helm.sh/helm/v3/pkg/getter"
 	"sigs.k8s.io/yaml"
 
@@ -15,12 +16,12 @@ func (spec *ChartSpec) GetValuesMap(p getter.Providers) (map[string]interface{},
 
 	err := yaml.Unmarshal([]byte(spec.ValuesYaml), &valuesYaml)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to Parse ValuesYaml")
+		return nil, fmt.Errorf("failed to parse ValuesYaml: %w", err)
 	}
 
 	valuesOptions, err := spec.ValuesOptions.MergeValues(p)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to Parse ValuesOptions")
+		return nil, fmt.Errorf("failed to parse ValuesOptions: %w", err)
 	}
 
 	return values.MergeMaps(valuesYaml, valuesOptions), nil

--- a/values/options.go
+++ b/values/options.go
@@ -23,12 +23,12 @@ Changes:
 package values
 
 import (
+	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
 	"helm.sh/helm/v3/pkg/getter"
@@ -65,7 +65,7 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		}
 
 		if err := yaml.Unmarshal(bytes, &currentMap); err != nil {
-			return nil, errors.Wrapf(err, "failed to parse %s", filePath)
+			return nil, fmt.Errorf("failed to parse %s: %w", filePath, err)
 		}
 		// Merge with the previous map
 		base = MergeMaps(base, currentMap)
@@ -74,21 +74,21 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 	// User specified a value via --set-json
 	for _, value := range opts.JSONValues {
 		if err := strvals.ParseJSON(value, base); err != nil {
-			return nil, errors.Errorf("failed parsing --set-json data %s", value)
+			return nil, fmt.Errorf("failed parsing --set-json data %s: %w", value, err)
 		}
 	}
 
 	// User specified a value via --set
 	for _, value := range opts.Values {
 		if err := strvals.ParseInto(value, base); err != nil {
-			return nil, errors.Wrap(err, "failed parsing --set data")
+			return nil, fmt.Errorf("failed parsing --set data: %w", err)
 		}
 	}
 
 	// User specified a value via --set-string
 	for _, value := range opts.StringValues {
 		if err := strvals.ParseIntoString(value, base); err != nil {
-			return nil, errors.Wrap(err, "failed parsing --set-string data")
+			return nil, fmt.Errorf("failed parsing --set-string data: %w", err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 			return string(bytes), err
 		}
 		if err := strvals.ParseIntoFile(value, base, reader); err != nil {
-			return nil, errors.Wrap(err, "failed parsing --set-file data")
+			return nil, fmt.Errorf("failed parsing --set-file data: %w", err)
 		}
 	}
 


### PR DESCRIPTION
The `github.com/pkg/errors` is not maintained and has been archived since a long time. The authors too recommend using the go stdlib errors package going forward