### PR TITLE
fix(permission denied): default ContentCache onto tmp

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,6 +37,7 @@ var storage = repo.File{}
 
 const (
 	defaultCachePath            = "/tmp/.helmcache"
+	defaultContentCachePath     = "/tmp/.helmcontent"
 	defaultRepositoryConfigPath = "/tmp/.helmrepo"
 )
 
@@ -132,6 +133,7 @@ func setEnvSettings(ppOptions **Options, settings *cli.EnvSettings) error {
 		*ppOptions = &Options{
 			RepositoryConfig: defaultRepositoryConfigPath,
 			RepositoryCache:  defaultCachePath,
+			ContentCache:     defaultContentCachePath,
 			Linting:          true,
 		}
 	}
@@ -157,8 +159,13 @@ func setEnvSettings(ppOptions **Options, settings *cli.EnvSettings) error {
 		options.RepositoryCache = defaultCachePath
 	}
 
+	if options.ContentCache == "" {
+		options.ContentCache = defaultContentCachePath
+	}
+
 	settings.RepositoryCache = options.RepositoryCache
 	settings.RepositoryConfig = options.RepositoryConfig
+	settings.ContentCache = options.ContentCache
 	settings.Debug = options.Debug
 
 	if options.RegistryConfig != "" {
@@ -893,6 +900,7 @@ func updateDependencies(helmChart *chart.Chart, chartPathOptions *action.ChartPa
 					Getters:          c.Providers,
 					RepositoryConfig: c.Settings.RepositoryConfig,
 					RepositoryCache:  c.Settings.RepositoryCache,
+					ContentCache:     c.Settings.ContentCache,
 					Out:              c.output,
 				}
 				if err := man.Update(); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -3,9 +3,11 @@ package helmclient
 import (
 	"bytes"
 	"context"
+	"testing"
 	"time"
 
 	"helm.sh/helm/v4/pkg/chart/common"
+	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
 
 	"helm.sh/helm/v4/pkg/action"
@@ -21,6 +23,7 @@ func ExampleNew() {
 		Namespace:        "default", // Change this to the namespace you wish the client to operate in.
 		RepositoryCache:  "/tmp/.helmcache",
 		RepositoryConfig: "/tmp/.helmrepo",
+		ContentCache:     "/tmp/.helmcontent",
 		Debug:            true,
 		Linting:          true,
 		DebugLog:         func(format string, v ...interface{}) {},
@@ -40,6 +43,7 @@ func ExampleNewClientFromRestConf() {
 			Namespace:        "default", // Change this to the namespace you wish the client to operate in.
 			RepositoryCache:  "/tmp/.helmcache",
 			RepositoryConfig: "/tmp/.helmrepo",
+			ContentCache:     "/tmp/.helmcontent",
 			Debug:            true,
 			Linting:          true, // Change this to false if you don't want linting.
 			DebugLog: func(format string, v ...interface{}) {
@@ -62,6 +66,7 @@ func ExampleNewClientFromKubeConf() {
 			Namespace:        "default", // Change this to the namespace you wish to install the chart in.
 			RepositoryCache:  "/tmp/.helmcache",
 			RepositoryConfig: "/tmp/.helmrepo",
+			ContentCache:     "/tmp/.helmcontent",
 			Debug:            true,
 			Linting:          true, // Change this to false if you don't want linting.
 			DebugLog: func(format string, v ...interface{}) {
@@ -77,6 +82,42 @@ func ExampleNewClientFromKubeConf() {
 		panic(err)
 	}
 	_ = helmClient
+}
+
+func TestSetEnvSettingsSetsDefaultContentCacheForNilOptions(t *testing.T) {
+	testDefaultContentCache(t, nil)
+}
+
+func TestSetEnvSettingsSetsDefaultContentCacheForEmptyOptions(t *testing.T) {
+	testDefaultContentCache(t, &Options{})
+}
+
+func testDefaultContentCache(t *testing.T, options *Options) {
+	t.Helper()
+
+	settings := cli.New()
+	if err := setEnvSettings(&options, settings); err != nil {
+		t.Fatal(err)
+	}
+
+	if settings.ContentCache != defaultContentCachePath {
+		t.Fatalf("expected default content cache %q, got %q", defaultContentCachePath, settings.ContentCache)
+	}
+}
+
+func TestSetEnvSettingsAllowsContentCacheOverride(t *testing.T) {
+	settings := cli.New()
+	options := &Options{
+		ContentCache: "/custom/content-cache",
+	}
+
+	if err := setEnvSettings(&options, settings); err != nil {
+		t.Fatal(err)
+	}
+
+	if settings.ContentCache != options.ContentCache {
+		t.Fatalf("expected content cache %q, got %q", options.ContentCache, settings.ContentCache)
+	}
 }
 
 func ExampleHelmClient_AddOrUpdateChartRepo_public() {

--- a/types.go
+++ b/types.go
@@ -39,6 +39,7 @@ type Options struct {
 	Namespace        string
 	RepositoryConfig string
 	RepositoryCache  string
+	ContentCache     string
 	Debug            bool
 	Linting          bool
 	DebugLog         DebugLog


### PR DESCRIPTION
@elenz97 please take a look. noroot/nologin containers, such as mine, can sometimes fail, due to the Content dir defaulting to $HOME, with the previous migration I have completely forgotten about it. 

Will look like this 

`error installing chart: mkdir /nonexistent: permission denied`

I already verified the fix, now it works as desired. 